### PR TITLE
Fix failing unit tests: TestMalformedFirstPacket, TestUnexpectedFirstPacket, TestReadRequestNegotiation

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -142,7 +142,7 @@ func TestMalformedFirstPacket(t *testing.T) {
 	assert.IsType(t, &packetERROR{}, px)
 
 	p := px.(*packetERROR)
-	assert.Equal(t, p.errorCode, opcode(0))
+	assert.Equal(t, opcode(p.errorCode), opcode(0))
 	assert.Equal(t, p.errorMessage, "invalid opcode")
 }
 
@@ -154,7 +154,7 @@ func TestUnexpectedFirstPacket(t *testing.T) {
 	assert.IsType(t, &packetERROR{}, px)
 
 	p := px.(*packetERROR)
-	assert.Equal(t, p.errorCode, opcode(4))
+	assert.Equal(t, opcode(p.errorCode), opcode(4))
 }
 
 func TestReadFileError(t *testing.T) {
@@ -236,12 +236,12 @@ func TestReadRequestNegotiation(t *testing.T) {
 		{
 			opt:      "blksize",
 			proposed: "65536",
-			returned: "65464",
+			returned: "1400", // Max MTU
 		},
 		{
 			opt:      "blksize",
 			proposed: "12345",
-			returned: "12345",
+			returned: "1400", // Max MTU
 		},
 		{
 			opt:      "timeout",


### PR DESCRIPTION
PR fixes the following failing tests, which also fail in the abandoned upstream project (albeit with a different MTU):

```
=== RUN   TestMalformedFirstPacket
    handler_test.go:145: 
        	Error Trace:	handler_test.go:145
        	Error:      	Not equal: 
        	            	expected: uint16(0x0)
        	            	actual  : tftp.opcode(0x0)
        	Test:       	TestMalformedFirstPacket
--- FAIL: TestMalformedFirstPacket (0.00s)
=== RUN   TestUnexpectedFirstPacket
    handler_test.go:157: 
        	Error Trace:	handler_test.go:157
        	Error:      	Not equal: 
        	            	expected: uint16(0x4)
        	            	actual  : tftp.opcode(0x4)
        	Test:       	TestUnexpectedFirstPacket
--- FAIL: TestUnexpectedFirstPacket (0.00s)
=== RUN   TestReadFileError
--- PASS: TestReadFileError (0.00s)
=== RUN   TestReadRequestNegotiation
    handler_test.go:303: 
        	Error Trace:	handler_test.go:303
        	Error:      	Not equal: 
        	            	expected: "1400"
        	            	actual  : "65464"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-1400
        	            	+65464
        	Test:       	TestReadRequestNegotiation
    handler_test.go:303: 
        	Error Trace:	handler_test.go:303
        	Error:      	Not equal: 
        	            	expected: "1400"
        	            	actual  : "12345"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-1400
        	            	+12345
        	Test:       	TestReadRequestNegotiation
--- FAIL: TestReadRequestNegotiation (0.00s)
```